### PR TITLE
Feature/reset phone and user info

### DIFF
--- a/src/main/kotlin/org/shangahi/sellio_backend/api/controller/AccountController.kt
+++ b/src/main/kotlin/org/shangahi/sellio_backend/api/controller/AccountController.kt
@@ -1,14 +1,13 @@
 package org.shangahi.sellio_backend.api.controller
 
-import org.shangahi.sellio_backend.api.dto.request.ChangePasswordRequest
-import org.shangahi.sellio_backend.api.dto.request.ResetPasswordRequest
-import org.shangahi.sellio_backend.api.dto.request.CreateUserRequest
-import org.shangahi.sellio_backend.api.dto.request.LoginRequest
-import org.shangahi.sellio_backend.api.dto.request.RefreshTokenRequest
-import org.shangahi.sellio_backend.api.dto.request.VerifyOtpRequest
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import jakarta.validation.Valid
+import org.shangahi.sellio_backend.api.dto.request.*
 import org.shangahi.sellio_backend.api.dto.response.AuthResponse
 import org.shangahi.sellio_backend.api.dto.response.OtpRequestResponse
 import org.shangahi.sellio_backend.api.swagger.doc.AccountDoc
+import org.shangahi.sellio_backend.service.AccountService
 import org.shangahi.sellio_backend.service.AuthenticationService
 import org.shangahi.sellio_backend.service.RegisterService
 import org.shangahi.sellio_backend.service.ResetPasswordService
@@ -18,14 +17,15 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
-import java.util.UUID
+import java.util.*
 
 @RestController
 @RequestMapping("/v1/auth")
 class AccountController(
     private val authenticationService: AuthenticationService,
     private val registerService: RegisterService,
-    private val resetPasswordService: ResetPasswordService
+    private val resetPasswordService: ResetPasswordService,
+    private val accountService: AccountService
 ) {
 
     @PostMapping("/login")
@@ -63,11 +63,38 @@ class AccountController(
         @RequestBody request: ChangePasswordRequest,
         @AuthenticationPrincipal userId: UUID
     ) {
-        return resetPasswordService.resetPassword(userId, request.currentPassword, request.newPassword, request.confirmPassword)
+        return resetPasswordService.resetPassword(
+            userId,
+            request.currentPassword,
+            request.newPassword,
+            request.confirmPassword
+        )
     }
 
     @PostMapping("/logout")
     fun logout(@AuthenticationPrincipal userId: UUID) {
         authenticationService.logout(userId)
     }
+
+    @PostMapping("/change-phone/initiate")
+    @Operation(summary = "Request OTP for new phone number", security = [SecurityRequirement(name = "bearer-key")])
+    fun initiateChangePhone(
+        @RequestBody @Valid request: ChangePhoneRequest,
+        @AuthenticationPrincipal userId: UUID
+    ): ResponseEntity<OtpRequestResponse> {
+        val response = accountService.initiatePhoneNumberChange(userId, request)
+        return ResponseEntity.ok(response)
+    }
+
+    @PostMapping("/change-phone/verify")
+    @Operation(summary = "Verify OTP and update phone number", security = [SecurityRequirement(name = "bearer-key")])
+    fun verifyChangePhone(
+        @RequestBody @Valid request: VerifyOtpRequest,
+        @AuthenticationPrincipal userId: UUID
+    ): ResponseEntity<String> {
+        accountService.verifyAndChangePhoneNumber(userId, request.sessionId, request.otp)
+        return ResponseEntity.ok("Phone number updated successfully")
+    }
+
+
 }

--- a/src/main/kotlin/org/shangahi/sellio_backend/api/controller/UserInfoController.kt
+++ b/src/main/kotlin/org/shangahi/sellio_backend/api/controller/UserInfoController.kt
@@ -21,7 +21,7 @@ class UserInfoController(
 ) {
 
     @UserDoc.UpdateUser
-    @PutMapping("/update")
+    @PatchMapping("/update")
     fun updateUser(
         @AuthenticationPrincipal userId: UUID,
         @Valid @RequestBody request: UserUpdateRequest,

--- a/src/main/kotlin/org/shangahi/sellio_backend/api/dto/request/ChangePhoneRequest.kt
+++ b/src/main/kotlin/org/shangahi/sellio_backend/api/dto/request/ChangePhoneRequest.kt
@@ -1,0 +1,10 @@
+package org.shangahi.sellio_backend.api.dto.request
+
+import jakarta.validation.constraints.NotBlank
+
+data class ChangePhoneRequest(
+    @field:NotBlank(message = "New phone number is required")
+    val phoneNumber: String,
+    @field:NotBlank(message = "Region is required")
+    val region: String,
+    )

--- a/src/main/kotlin/org/shangahi/sellio_backend/api/dto/request/UserUpdateRequest.kt
+++ b/src/main/kotlin/org/shangahi/sellio_backend/api/dto/request/UserUpdateRequest.kt
@@ -1,14 +1,18 @@
 package org.shangahi.sellio_backend.api.dto.request
 
 import jakarta.validation.constraints.Email
+import jakarta.validation.constraints.Size
 
 data class UserUpdateRequest(
+    @field:Size(min = 2, max = 50)
     val firstName: String?,
+    @field:Size(min = 2, max = 50)
     val lastName: String?,
-    val phoneNumber: String?,
     @field:Email(message = "Invalid email format")
+    @field:Size(min = 2, max = 100)
     val email: String?,
+    @field:Size(min = 2, max = 60)
     val city: String?,
+    @field:Size(min = 2, max = 60)
     val country: String?,
-    val avatarUrl: String?,
 )

--- a/src/main/kotlin/org/shangahi/sellio_backend/api/swagger/doc/UserDoc.kt
+++ b/src/main/kotlin/org/shangahi/sellio_backend/api/swagger/doc/UserDoc.kt
@@ -122,7 +122,6 @@ annotation class UserDoc {
                               "firstName": "Not Ahmed",
                               "lastName": "Sayed",
                               "email": null,
-                              "phoneNumber": "01111111111",
                               "city": "Cairo",
                               "country": "Egypt",
                               "avatarUrl": null

--- a/src/main/kotlin/org/shangahi/sellio_backend/security/config/SecurityConfig.kt
+++ b/src/main/kotlin/org/shangahi/sellio_backend/security/config/SecurityConfig.kt
@@ -43,7 +43,8 @@ class SecurityConfig(
                     "/v1/store-rating/**",
                     "v1/subcategories/store/*",
                     "/v1/subcategories/category/*",
-                    "/v1/offers"
+                    "/v1/offers",
+                    "/v1/thrift-products"
                 ).permitAll()
                     .anyRequest().authenticated()
             }

--- a/src/main/kotlin/org/shangahi/sellio_backend/service/AccountService.kt
+++ b/src/main/kotlin/org/shangahi/sellio_backend/service/AccountService.kt
@@ -1,0 +1,70 @@
+package org.shangahi.sellio_backend.service
+
+import org.shangahi.sellio_backend.api.dto.request.ChangePhoneRequest
+import org.shangahi.sellio_backend.api.dto.response.OtpRequestResponse
+import org.shangahi.sellio_backend.repository.OtpLogRepository
+import org.shangahi.sellio_backend.security.service.PhoneNumberValidatorService
+import org.shangahi.sellio_backend.security.service.otp.SmsSender
+import org.shangahi.sellio_backend.service.exception.SamePhoneNumberException
+import org.shangahi.sellio_backend.service.exception.SessionIdNotFoundException
+import org.shangahi.sellio_backend.service.exception.UserPhoneNumberAlreadyExistsException
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.util.*
+
+@Service
+class AccountService(
+    private val userService: UserService,
+    private val otpService: OtpService,
+    private val phoneNumberValidator: PhoneNumberValidatorService,
+    private val smsSender: SmsSender,
+    private val otpLogRepository: OtpLogRepository
+) {
+
+    @Transactional
+    fun initiatePhoneNumberChange(userId: UUID, request: ChangePhoneRequest): OtpRequestResponse {
+        val validated = phoneNumberValidator.validate(request.phoneNumber, request.region)
+
+        val currentUser = userService.findById(userId)
+
+        if (currentUser.phoneNumber == validated.phoneNumber) {
+            throw SamePhoneNumberException()
+        }
+
+        if (userService.findUserByPhoneNumber(validated.phoneNumber) != null) {
+            throw UserPhoneNumberAlreadyExistsException()
+        }
+
+        val sessionId = UUID.randomUUID()
+
+        val otpLog = otpService.createOtp(validated.phoneNumber, sessionId)
+
+        smsSender.sendSms(validated.countryCode, validated.phoneNumber, otpLog.otp)
+
+        return OtpRequestResponse(otpLog.sessionId.toString())
+    }
+
+    @Transactional
+    fun verifyAndChangePhoneNumber(userId: UUID, sessionId: String, otp: String) {
+        val sessionId = UUID.fromString(sessionId)
+
+        otpService.verifyOtp(sessionId, otp)
+
+        val otpLog = otpLogRepository.findLatestBySessionId(sessionId)
+            ?: throw SessionIdNotFoundException()
+        val newPhoneNumber = otpLog.phoneNumber
+
+        if (userService.findUserByPhoneNumber(newPhoneNumber) != null) {
+            throw UserPhoneNumberAlreadyExistsException()
+        }
+
+        val user = userService.findById(userId)
+
+        val updatedUser = user.copy(
+            phoneNumber = newPhoneNumber,
+            updatedAt = java.time.Instant.now()
+        )
+        userService.saveUser(updatedUser)
+        otpService.expireOtpBySessionId(sessionId)
+    }
+}

--- a/src/main/kotlin/org/shangahi/sellio_backend/service/UserService.kt
+++ b/src/main/kotlin/org/shangahi/sellio_backend/service/UserService.kt
@@ -70,7 +70,7 @@ class UserService(
         return userRepository.save(updatedUser)
     }
 
-
+    @Transactional
     fun updateUser(
         userId: UUID,
         request: UserUpdateRequest
@@ -79,13 +79,6 @@ class UserService(
         val existingUser = userRepository.findByIdAndIsDeletedFalse(userId)
             ?: throw UserNotFoundException()
 
-        if (
-            request.phoneNumber != null &&
-            request.phoneNumber != existingUser.phoneNumber &&
-            userRepository.existsByPhoneNumberAndIsDeletedFalse(request.phoneNumber)
-        ) {
-            throw UserPhoneNumberAlreadyExistsException()
-        }
         if (
             request.email != null &&
             request.email != existingUser.email &&
@@ -96,11 +89,9 @@ class UserService(
         val updatedUser = existingUser.copy(
             firstName = request.firstName ?: existingUser.firstName,
             lastName = request.lastName ?: existingUser.lastName,
-            phoneNumber = request.phoneNumber ?: existingUser.phoneNumber,
             email = request.email ?: existingUser.email,
             city = request.city ?: existingUser.city,
             country = request.country ?: existingUser.country,
-            avatarUrl = request.avatarUrl ?: existingUser.avatarUrl
         )
         return userRepository.save(updatedUser)
     }

--- a/src/main/kotlin/org/shangahi/sellio_backend/service/exception/AuthenticationException.kt
+++ b/src/main/kotlin/org/shangahi/sellio_backend/service/exception/AuthenticationException.kt
@@ -30,6 +30,12 @@ class InvalidPhoneNumberException : SellioException (
     code = INVALID_PHONE_NUMBER
 )
 
+class SamePhoneNumberException : SellioException (
+    message = "New phone number cannot be the same as the current one",
+    httpStatus = HttpStatus.BAD_REQUEST,
+    code = INVALID_PHONE_NUMBER
+)
+
 class InvalidPhoneNumberRegionException : SellioException (
     message = "Invalid phone number region",
     httpStatus = HttpStatus.BAD_REQUEST,


### PR DESCRIPTION
##  Description
This PR refactors the user profile management logic to enhance security and usability.
It separates the "sensitive data update" (Phone Number) from the "basic info update" (Name, City, etc.).
A new **Two-Step Verification flow** is introduced for changing the phone number to verify ownership of the new number via OTP before updating the database.


| Method | Endpoint | Description |
| :--- | :--- | :--- |
| `POST` | `/v1/profile/change-phone/initiate` | Request OTP for a new phone number. |
| `POST` | `/v1/profile/change-phone/verify` | Verify OTP and update phone number. |
| `PATCH` | `/v1/user/update` | Update basic info (Name, Email, City, Country). |

