### PR TITLE
Refactor/reset password

### DIFF
--- a/src/main/kotlin/org/shangahi/sellio_backend/api/controller/AccountController.kt
+++ b/src/main/kotlin/org/shangahi/sellio_backend/api/controller/AccountController.kt
@@ -60,15 +60,10 @@ class AccountController(
     @PostMapping("/reset-password")
     @AccountDoc.ChangePassword
     fun resetPassword(
-        @RequestBody request: ChangePasswordRequest,
+        @RequestBody @Valid request: ChangePasswordRequest,
         @AuthenticationPrincipal userId: UUID
     ) {
-        return resetPasswordService.resetPassword(
-            userId,
-            request.currentPassword,
-            request.newPassword,
-            request.confirmPassword
-        )
+        return resetPasswordService.resetPassword(userId, request.currentPassword, request.newPassword )
     }
 
     @PostMapping("/logout")

--- a/src/main/kotlin/org/shangahi/sellio_backend/api/controller/AccountController.kt
+++ b/src/main/kotlin/org/shangahi/sellio_backend/api/controller/AccountController.kt
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import jakarta.validation.Valid
 import org.shangahi.sellio_backend.api.dto.request.*
 import org.shangahi.sellio_backend.api.dto.response.AuthResponse
+import org.shangahi.sellio_backend.api.dto.response.MessageResponse
 import org.shangahi.sellio_backend.api.dto.response.OtpRequestResponse
 import org.shangahi.sellio_backend.api.swagger.doc.AccountDoc
 import org.shangahi.sellio_backend.service.AccountService
@@ -62,8 +63,9 @@ class AccountController(
     fun resetPassword(
         @RequestBody @Valid request: ChangePasswordRequest,
         @AuthenticationPrincipal userId: UUID
-    ) {
-        return resetPasswordService.resetPassword(userId, request.currentPassword, request.newPassword )
+    ): ResponseEntity<MessageResponse> {
+        resetPasswordService.resetPassword(userId, request.currentPassword, request.newPassword)
+        return ResponseEntity.ok(MessageResponse("Password reset successfully"))
     }
 
     @PostMapping("/logout")

--- a/src/main/kotlin/org/shangahi/sellio_backend/api/dto/request/ChangePasswordRequest.kt
+++ b/src/main/kotlin/org/shangahi/sellio_backend/api/dto/request/ChangePasswordRequest.kt
@@ -7,9 +7,7 @@ data class ChangePasswordRequest(
     @field:NotBlank
     val currentPassword: String,
 
-    @field:NotBlank @field:Size(min = 8)
+    @field:NotBlank
+    @field:Size(min = 8, message = "Password must be at least 8 characters")
     val newPassword: String,
-
-    @field:NotBlank @field:Size(min = 8)
-    val confirmPassword: String
 )

--- a/src/main/kotlin/org/shangahi/sellio_backend/api/dto/response/MessageResponse.kt
+++ b/src/main/kotlin/org/shangahi/sellio_backend/api/dto/response/MessageResponse.kt
@@ -1,0 +1,5 @@
+package org.shangahi.sellio_backend.api.dto.response
+
+data class MessageResponse(
+    val message: String
+)

--- a/src/main/kotlin/org/shangahi/sellio_backend/api/swagger/doc/AccountDoc.kt
+++ b/src/main/kotlin/org/shangahi/sellio_backend/api/swagger/doc/AccountDoc.kt
@@ -404,7 +404,6 @@ annotation class AccountDoc {
                             {
                               "currentPassword": "OldPassword123!",
                               "newPassword": "NewPassword123!",
-                              "confirmPassword": "NewPassword123!"
                             }
                             """
                         )
@@ -414,22 +413,6 @@ annotation class AccountDoc {
         ),
         responses = [
             ApiResponse(responseCode = "200", description = "Password updated successfully"),
-            ApiResponse(
-                responseCode = "401",
-                description = "Invalid current password",
-                content = [
-                    Content(
-                        mediaType = "application/json",
-                        schema = Schema(implementation = ErrorResponse::class),
-                        examples = [
-                            ExampleObject(
-                                name = "InvalidCurrentPassword",
-                                value = ErrorResponseExample.AUTH_INVALID_CREDENTIALS
-                            )
-                        ]
-                    )
-                ]
-            ),
             ApiResponse(
                 responseCode = "400",
                 description = "New password mismatch or validation error",

--- a/src/main/kotlin/org/shangahi/sellio_backend/service/ResetPasswordService.kt
+++ b/src/main/kotlin/org/shangahi/sellio_backend/service/ResetPasswordService.kt
@@ -1,10 +1,9 @@
 package org.shangahi.sellio_backend.service
 
-import org.shangahi.sellio_backend.service.exception.PasswordNotMatchException
-import org.shangahi.sellio_backend.service.exception.UnauthorizedException
+import org.shangahi.sellio_backend.service.exception.CurrentPasswordIncorrectException
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
-import java.util.UUID
+import java.util.*
 
 @Service
 class ResetPasswordService(
@@ -16,16 +15,12 @@ class ResetPasswordService(
         userId: UUID,
         currentPassword: String,
         newPassword: String,
-        confirmPassword: String
     ) {
-        if (newPassword != confirmPassword) {
-            throw PasswordNotMatchException()
-        }
 
         val user = userService.findById(userId)
 
         if (!passwordEncoder.matches(currentPassword, user.password)) {
-            throw UnauthorizedException()
+            throw CurrentPasswordIncorrectException()
         }
 
         val updatedUser = user.copy(password = passwordEncoder.encode(newPassword))

--- a/src/main/kotlin/org/shangahi/sellio_backend/service/exception/AuthenticationException.kt
+++ b/src/main/kotlin/org/shangahi/sellio_backend/service/exception/AuthenticationException.kt
@@ -54,6 +54,13 @@ class PasswordNotMatchException : SellioException (
     code = AUTH_PASSWORD_NOT_MATCH
 )
 
+
+class CurrentPasswordIncorrectException : SellioException(
+    message = "Current password is incorrect",
+    httpStatus = HttpStatus.BAD_REQUEST,
+    code = AUTH_INVALID_CREDENTIALS
+)
+
 class InvalidOtpException : SellioException (
     message = "Invalid OTP",
     httpStatus = HttpStatus.BAD_REQUEST,


### PR DESCRIPTION

### Reset Password
**Endpoint:** `POST /v1/auth/reset-password`
**Auth:** Bearer Token (Required)

**Request Body:**
```json
{
  "currentPassword": "old_password_123",
  "newPassword": "new_secure_password"
}
```
- Removed `confirmPassword` from backend DTO and logic

###  Mobile Optimization (Error Handling)
- **Problem:** Returning `401` for a wrong password caused mobile to trigger automatic token refresh loops, thinking the session expired.
- **Solution:** Created `CurrentPasswordIncorrectException` mapped to **HTTP 400 (Bad Request)**. This ensures the client treats it as a validation error, not an auth error.

###  API Response
- The endpoint now returns a structured JSON response `{ "message": "..." }` instead of a plain string or empty body, ensuring consistent JSON parsing on the frontend.
