### PR TITLE
Refactor/remove password confirmation

### DIFF
--- a/src/main/kotlin/org/shangahi/sellio_backend/api/controller/ForgotPasswordController.kt
+++ b/src/main/kotlin/org/shangahi/sellio_backend/api/controller/ForgotPasswordController.kt
@@ -1,5 +1,6 @@
 package org.shangahi.sellio_backend.api.controller
 
+import jakarta.validation.Valid
 import org.shangahi.sellio_backend.api.dto.request.RequestOtpRequest
 import org.shangahi.sellio_backend.api.dto.request.ResetPasswordRequest
 import org.shangahi.sellio_backend.api.dto.request.VerifyOtpRequest
@@ -34,7 +35,7 @@ class ForgotPasswordController(
 
     @PostMapping("/reset")
     @ForgotPasswordDoc.ResetPassword
-    fun resetPassword(@RequestBody request: ResetPasswordRequest) {
+    fun resetPassword(@RequestBody @Valid request: ResetPasswordRequest) {
         forgotPasswordService.resetPassword(
             sessionId = request.sessionId,
             newPassword = request.newPassword,

--- a/src/main/kotlin/org/shangahi/sellio_backend/api/controller/ForgotPasswordController.kt
+++ b/src/main/kotlin/org/shangahi/sellio_backend/api/controller/ForgotPasswordController.kt
@@ -1,10 +1,15 @@
 package org.shangahi.sellio_backend.api.controller
 
-import org.shangahi.sellio_backend.api.dto.request.*
+import org.shangahi.sellio_backend.api.dto.request.RequestOtpRequest
+import org.shangahi.sellio_backend.api.dto.request.ResetPasswordRequest
+import org.shangahi.sellio_backend.api.dto.request.VerifyOtpRequest
 import org.shangahi.sellio_backend.api.dto.response.OtpRequestResponse
 import org.shangahi.sellio_backend.api.swagger.doc.ForgotPasswordDoc
 import org.shangahi.sellio_backend.service.ForgotPasswordService
-import org.springframework.web.bind.annotation.*
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/v1/forgot-password")
@@ -33,7 +38,6 @@ class ForgotPasswordController(
         forgotPasswordService.resetPassword(
             sessionId = request.sessionId,
             newPassword = request.newPassword,
-            confirmPassword = request.confirmPassword
         )
     }
 }

--- a/src/main/kotlin/org/shangahi/sellio_backend/api/dto/request/ResetPasswordRequest.kt
+++ b/src/main/kotlin/org/shangahi/sellio_backend/api/dto/request/ResetPasswordRequest.kt
@@ -11,7 +11,4 @@ data class ResetPasswordRequest(
 
     @field:NotBlank @field:Size(min = 8, message = "newPassword must be at least 8 characters long")
     val newPassword: String,
-
-    @field:NotBlank @field:Size(min = 8, message = "newPassword must be at least 8 characters long")
-    val confirmPassword: String
 )

--- a/src/main/kotlin/org/shangahi/sellio_backend/api/swagger/doc/AccountDoc.kt
+++ b/src/main/kotlin/org/shangahi/sellio_backend/api/swagger/doc/AccountDoc.kt
@@ -403,7 +403,7 @@ annotation class AccountDoc {
                             value = """
                             {
                               "currentPassword": "OldPassword123!",
-                              "newPassword": "NewPassword123!",
+                              "newPassword": "NewPassword123!"
                             }
                             """
                         )

--- a/src/main/kotlin/org/shangahi/sellio_backend/api/swagger/doc/ForgotPasswordDoc.kt
+++ b/src/main/kotlin/org/shangahi/sellio_backend/api/swagger/doc/ForgotPasswordDoc.kt
@@ -203,8 +203,7 @@ annotation class ForgotPasswordDoc {
                             value = """
                             {
                               "sessionId": "f47ac10b-58cc-4372-a567-0e02b2c3d479",
-                              "newPassword": "NewPassword123!",
-                              "confirmPassword": "NewPassword123!"
+                              "newPassword": "NewPassword123!"
                             }
                             """
                         )

--- a/src/main/kotlin/org/shangahi/sellio_backend/service/ForgotPasswordService.kt
+++ b/src/main/kotlin/org/shangahi/sellio_backend/service/ForgotPasswordService.kt
@@ -5,7 +5,6 @@ import org.shangahi.sellio_backend.repository.OtpLogRepository
 import org.shangahi.sellio_backend.repository.UserRepository
 import org.shangahi.sellio_backend.security.service.PhoneNumberValidatorService
 import org.shangahi.sellio_backend.security.service.otp.SmsSender
-import org.shangahi.sellio_backend.service.exception.PasswordNotMatchException
 import org.shangahi.sellio_backend.service.exception.SessionIdNotFoundException
 import org.shangahi.sellio_backend.service.exception.UserNotFoundException
 import org.springframework.security.crypto.password.PasswordEncoder
@@ -43,10 +42,7 @@ class ForgotPasswordService(
         otpService.verifyOtp(uuid, otp)
     }
 
-    fun resetPassword(sessionId: String, newPassword: String, confirmPassword: String) {
-        if (newPassword != confirmPassword) {
-            throw PasswordNotMatchException()
-        }
+    fun resetPassword(sessionId: String, newPassword: String) {
 
         val uuid = UUID.fromString(sessionId)
 


### PR DESCRIPTION
### PR Title
`refactor: Remove confirmPassword from Forgot Password API`

### PR Description

### 1. API Contract Update
- **DTO:** Removed `confirmPassword` field from `ResetPasswordRequest`.
- **Controller:** Updated `ForgotPasswordController` to accept the simplified request body.

### 2. Business Logic
- **Service:** Removed the equality check (`newPassword == confirmPassword`) from `ForgotPasswordService`.
- **Validation:** Relies on strict Jakarta Validation (`@Size`, `@NotBlank`) to ensure `newPassword` meets security standards (min 8 chars).

##  API Example

**Endpoint:** `POST /v1/forgot-password/reset`

**Old Request:**
```json
{
  "sessionId": "uuid",
  "newPassword": "pass",
  "confirmPassword": "pass"
}
```
**New Request:**
```json
{
  "sessionId": "uuid",
  "newPassword": "pass"
}
```