### PR TITLE
fix: handle POST redirect issue in CountryCityRepositoryImp

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,6 +46,8 @@ dependencies {
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 
     implementation("org.springframework.boot:spring-boot-starter-webflux")
+    implementation("org.apache.httpcomponents.client5:httpclient5")
+
 }
 
 kotlin {

--- a/src/main/kotlin/org/shangahi/sellio_backend/repository/countrycity/CountryCityRepositoryImp.kt
+++ b/src/main/kotlin/org/shangahi/sellio_backend/repository/countrycity/CountryCityRepositoryImp.kt
@@ -8,16 +8,20 @@ import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpMethod
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory
 import org.springframework.stereotype.Repository
 import org.springframework.web.client.RestClientResponseException
 import org.springframework.web.client.exchange
+import java.util.function.Supplier
 
 @Repository
 class CountryCityRepositoryImp(
     restTemplateBuilder: RestTemplateBuilder
 ) : CountryCityRepository {
 
-    private val restTemplate = restTemplateBuilder.build()
+    private val restTemplate = restTemplateBuilder
+        .requestFactory(Supplier { HttpComponentsClientHttpRequestFactory() })
+        .build()
 
     override fun getCitiesByCountryIso2(iso2: String): CitiesModel {
         return try {


### PR DESCRIPTION
**Previously, our CountryCityRepository was using the default
RestTemplate, which does not follow POST redirects. This caused
301 MOVED_PERMANENTLY errors when fetching cities from
countriesnow.space.**

now we fixed that and `/v1/countries/{iso2}/cities` now works reliably